### PR TITLE
chore: implement IL customizations on new repo

### DIFF
--- a/examples/ephemeral/.terraform.lock.hcl
+++ b/examples/ephemeral/.terraform.lock.hcl
@@ -2,45 +2,45 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "6.22.1"
-  constraints = ">= 5.0.0, >= 6.0.0, >= 6.21.0"
+  version     = "6.37.0"
+  constraints = ">= 5.0.0, >= 6.21.0"
   hashes = [
-    "h1:PTgxp+nMDBd6EFHAIH6ceFfvwa2blqkCwXglZn6Dqa8=",
-    "zh:3995ca97e6c2c1ed9e231c453287585d3dc1ca2a304683ac0b269b3448fda7c0",
-    "zh:4f69f70d2edeb0dde9c693b7cd7e8e21c781b2fac7062bed5300092dbadb71e1",
-    "zh:5c76042fdf3df56a1f581bc477e5d6fc3e099d4d6544fe725b3747e9990726bd",
-    "zh:6ff8221340955f4b3ba9230918bb026c4414a5aebe9d0967845c43e8e8908aec",
-    "zh:73cdd8638cb52bbe25887cd5b7946cc3fcb891867de11bcb0fde9b35c4f70a41",
-    "zh:7af5aec2fd01fa5e5f600f1db1bcf200aaadc05a2c8ffcbb4b6b61cd2bd3e33b",
-    "zh:7e055cfa7f40b667f5f7af564db9544f46aa189cdbe5530ad812e027647132f5",
+    "h1:w3z/TApcKD3b/aMZoZZKSxOld4xw+gEtQ1ka6C1UN+4=",
+    "zh:0427fadb719ed5a32feb09f047539d2348e659056f3b8a8589d34d8f0a95be7a",
+    "zh:3891c670674aba2125a7ac6d4348cde43646b1b46ce6f829e6f4724091bc0dcd",
+    "zh:632cb24b7b5790b730b33bcbe9f1a7b75f2644fb52f9d6aaafb0249c9e7601d2",
+    "zh:6e96ed1f824c2efa9de5b7c22ab3715624ba34c28564a06e9a15e71bc3d3a30b",
+    "zh:7b8fd86907b659bc45f4a3f42c3c0ccc66925a74e265b01e9e66242c0b2cafef",
+    "zh:81f9a587deddef4dfcc2101c54ec28a3a554056837f68ebb920c83fe8327b16f",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:aba898190c668ade4471da65c96db414679367174ac5b73e8ce7551056c77e3e",
-    "zh:aedaa8d7d71e6d58cdc09a7e3bcb8031b3ea496a7ac142376eb679d1756057f3",
-    "zh:cb9739952d467b3f6d72d57722943956e80ab235b58a0e34758538381dcc386c",
-    "zh:e12a2681028a70cb08eaf4c3364ddab386416502f966067bf99e79ba6be0d7b6",
-    "zh:e32a922a7d6fd5df69b3cc92932fc2689dc195b0f8b493dcd686abdd892b06cd",
-    "zh:f2dea7dead6f34b51e8b6aae177a8b333834a41d25529baa634a087d99ea32f6",
-    "zh:f6eee6df0366e8452d912cfd498792579aede88de3b67c15d36b8949e37479b1",
+    "zh:a9a38a67cb98d690fec951ec3e133b6836279629db2ed3a0ebf97a5bea58674f",
+    "zh:b18f60d62e4bd4d466077e09c39259d1a85355f0f00b801fe8aedbc50193d357",
+    "zh:b7a51bc0faf60d17043b4df1d1b7bb55129eaa4bdeb65ff55f5b00b9b8fee9f7",
+    "zh:c28c42f91ca3a6b65b3fd3ed6e891fc0fc28d0cb5ab65dea65eda8eec5cea5f3",
+    "zh:d895ddc04280ed26b6ca64ca05b78caaa7b72c8e167af4093545efbc608d5482",
+    "zh:f4a56f5157009ef160fbd79105078fe675df479cb73c1b7e1fea2741403a0b67",
+    "zh:f547d6ca371b96fec97b972fc0c93bcfc23d58e34a9da215b94e9d2aa170fb77",
+    "zh:f7b0a3cd4adadd3f4b9609a54e651ed5eafa22c196ab229042fc1d0aa0ab8f3a",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/local" {
-  version     = "2.6.1"
+  version     = "2.7.0"
   constraints = "~> 2.0"
   hashes = [
-    "h1:DbiR/D2CPigzCGweYIyJH0N0x04oyI5xiZ9wSW/s3kQ=",
-    "zh:10050d08f416de42a857e4b6f76809aae63ea4ec6f5c852a126a915dede814b4",
-    "zh:2df2a3ebe9830d4759c59b51702e209fe053f47453cb4688f43c063bac8746b7",
-    "zh:2e759568bcc38c86ca0e43701d34cf29945736fdc8e429c5b287ddc2703c7b18",
-    "zh:6a62a34e48500ab4aea778e355e162ebde03260b7a9eb9edc7e534c84fbca4c6",
-    "zh:74373728ba32a1d5450a3a88ac45624579e32755b086cd4e51e88d9aca240ef6",
+    "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
+    "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
+    "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
+    "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
+    "zh:643256547b155459c45e0a3e8aab0570db59923c68daf2086be63c444c8c445b",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8dddae588971a996f622e7589cd8b9da7834c744ac12bfb59c97fa77ded95255",
-    "zh:946f82f66353bb97aefa8d95c4ca86db227f9b7c50b82415289ac47e4e74d08d",
-    "zh:e9a5c09e6f35e510acf15b666fd0b34a30164cecdcd81ce7cda0f4b2dade8d91",
-    "zh:eafe5b873ef42b32feb2f969c38ff8652507e695620cbaf03b9db714bee52249",
-    "zh:ec146289fa27650c9d433bb5c7847379180c0b7a323b1b94e6e7ad5d2a7dbe71",
-    "zh:fc882c35ce05631d76c0973b35adde26980778fc81d9da81a2fade2b9d73423b",
+    "zh:7aa4d0b853f84205e8cf79f30c9b2c562afbfa63592f7231b6637e5d7a6b5b27",
+    "zh:7dc251bbc487d58a6ab7f5b07ec9edc630edb45d89b761dba28e0e2ba6b1c11f",
+    "zh:7ee0ca546cd065030039168d780a15cbbf1765a4c70cd56d394734ab112c93da",
+    "zh:b1d5d80abb1906e6c6b3685a52a0192b4ca6525fe090881c64ec6f67794b1300",
+    "zh:d81ea9856d61db3148a4fc6c375bf387a721d78fc1fea7a8823a027272a47a78",
+    "zh:df0a1f0afc947b8bfc88617c1ad07a689ce3bd1a29fd97318392e6bdd32b230b",
+    "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
   ]
 }
 
@@ -49,6 +49,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = "~> 3.0, ~> 3.2"
   hashes = [
     "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
@@ -65,21 +66,21 @@ provider "registry.terraform.io/hashicorp/null" {
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.7.2"
+  version     = "3.8.1"
   constraints = "~> 3.0"
   hashes = [
-    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
-    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
-    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
-    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
-    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
-    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
-    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
-    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
-    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
-    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
-    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
   ]
 }

--- a/examples/ephemeral/init.sh
+++ b/examples/ephemeral/init.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+set -e
+
+if [ ! -f ./.env ]; then
+    echo "error: Can't find .env file. Please set vars in .env file using .env.example as a template"
+    exit 1
+fi
+
+. ./.env
+
+# ensure vars used below are set
+
+if [ "x$TERRAFORM_S3_BUCKET" = "x" ]; then
+    echo "error: TERRAFORM_S3_BUCKET not set. Please set vars in .env file"
+    exit 1
+fi
+if [ "x$TERRAFORM_S3_KEY" = "x" ]; then
+    echo "error: TERRAFORM_S3_KEY not set. Please set vars in .env file"
+    exit 1
+fi
+if [ "x$AWS_DEFAULT_REGION" = "x" ]; then
+    echo "error: AWS_DEFAULT_REGION not set. Please set vars in .env file"
+    exit 1
+fi
+if [ "x$TERRAFORM_DYNAMODB_LOCK_TABLE" = "x" ]; then
+    echo "error: TERRAFORM_DYNAMODB_LOCK_TABLE not set. Please set vars in .env file"
+    exit 1
+fi
+
+terraform init -backend=true \
+  -backend-config="bucket=$TERRAFORM_S3_BUCKET" \
+  -backend-config="key=$TERRAFORM_S3_KEY" \
+  -backend-config="region=$AWS_DEFAULT_REGION" \
+  -backend-config="dynamodb_table=$TERRAFORM_DYNAMODB_LOCK_TABLE" \
+  -backend-config="encrypt=true" -upgrade

--- a/examples/ephemeral/main.tf
+++ b/examples/ephemeral/main.tf
@@ -14,6 +14,18 @@ module "base" {
   aws_region = local.aws_region
 }
 
+module "s3_cache" {
+  source = "./s3_cache"
+
+  config = {
+    aws_region       = local.aws_region
+    prefix           = local.environment
+    runner_role_arns = [module.runners.runners.role_runner.arn]
+    tags             = { Project = "IL-AWS-Runners" }
+    vpc_id           = module.base.vpc.vpc_id
+  }
+}
+
 module "runners" {
   source                          = "../../"
   create_service_linked_role_spot = true
@@ -23,7 +35,7 @@ module "runners" {
 
   prefix = local.environment
   tags = {
-    Project = "ProjectX"
+    Project = "IL-AWS-Runners"
   }
 
   github_app = {
@@ -36,20 +48,31 @@ module "runners" {
   # Alternatively you can set the path to the lambda zip files here.
   #
   # For example grab zip files via lambda_download
-  # webhook_lambda_zip                = "../lambdas-download/webhook.zip"
-  # runner_binaries_syncer_lambda_zip = "../lambdas-download/runner-binaries-syncer.zip"
-  # runners_lambda_zip                = "../lambdas-download/runners.zip"
+  webhook_lambda_zip                = "../lambdas-download/webhook.zip"
+  runner_binaries_syncer_lambda_zip = "../lambdas-download/runner-binaries-syncer.zip"
+  runners_lambda_zip                = "../lambdas-download/runners.zip"
 
   enable_organization_runners = true
-  runner_extra_labels         = ["default", "example"]
+  runner_extra_labels         = ["ephemeral"]
 
   # enable access to the runners via SSM
   enable_ssm_on_runners = true
 
+
+  block_device_mappings = [{
+    device_name           = "/dev/sda1"
+    delete_on_termination = true
+    volume_type           = "gp3"
+    volume_size           = 50
+    iops                  = null
+  }]
+
+  runner_run_as = "ubuntu"
+
   # Let the module manage the service linked role
   # create_service_linked_role_spot = true
 
-  instance_types = ["m5.large", "c5.large"]
+  instance_types = ["m7a.xlarge", "c7a.xlarge"]
 
   # override delay of events in seconds
   delay_webhook_event = 0
@@ -82,11 +105,11 @@ module "runners" {
 
 
   # configure your pre-built AMI
-  # enable_userdata = false
-  # ami = {
-  #   filter = { name = ["github-runner-al2023-x86_64-*"], state = ["available"] }
-  #   owners = [data.aws_caller_identity.current.account_id]
-  # }
+  enable_userdata = false
+  ami = {
+    filter = { name = ["github-runner-ubuntu-noble-amd64-*"], state = ["available"] }
+    owners = ["682864570400"]
+  }
 
   # or use the default AMI
   # enable_userdata = true
@@ -94,7 +117,7 @@ module "runners" {
   # Enable debug logging for the lambda functions
   # log_level = "debug"
 
-  # Setup a dead letter queue, by default scale up lambda will keep retrying to process event in case of scaling error.
+  # Setup a dead letter queue, by default scale up lambda will kepp retrying to process event in case of scaling error.
   # redrive_policy_build_queue = {
   #   enabled             = true
   #   maxReceiveCount     = 50 # 50 retries every 30 seconds => 25 minutes

--- a/examples/ephemeral/s3_cache/README.md
+++ b/examples/ephemeral/s3_cache/README.md
@@ -1,0 +1,41 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.27 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.27 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_s3_bucket.runner_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.runner_cache_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_policy.runner_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [aws_iam_policy_document.runner_cache_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_route_tables.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_config"></a> [config](#input\_config) | n/a | <pre>object({<br/>    aws_region       = string<br/>    prefix           = string<br/>    runner_role_arns = list(string)<br/>    tags             = map(string)<br/>    vpc_id           = string<br/>  })</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/examples/ephemeral/s3_cache/main.tf
+++ b/examples/ephemeral/s3_cache/main.tf
@@ -1,0 +1,58 @@
+resource "random_string" "random" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+data "aws_route_tables" "private" {
+  vpc_id = var.config.vpc_id
+  filter {
+    name   = "tag:Name"
+    values = ["*private"]
+  }
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id          = var.config.vpc_id
+  route_table_ids = data.aws_route_tables.private.ids
+  service_name    = "com.amazonaws.${var.config.aws_region}.s3"
+}
+
+resource "aws_s3_bucket" "runner_cache" {
+  bucket        = "${var.config.prefix}-cache-${random_string.random.result}"
+  force_destroy = true
+  tags          = var.config.tags
+}
+
+data "aws_iam_policy_document" "runner_cache_policy" {
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = var.config.runner_role_arns
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.runner_cache.arn,
+      "${aws_s3_bucket.runner_cache.arn}/*"
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "runner_cache" {
+  bucket = aws_s3_bucket.runner_cache.id
+  policy = data.aws_iam_policy_document.runner_cache_policy.json
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "runner_cache_bucket_lifecycle_configuration" {
+  bucket = aws_s3_bucket.runner_cache.id
+  rule {
+    id = "expire-cache"
+    filter {}
+    expiration {
+      days = 3
+    }
+    status = "Enabled"
+  }
+}

--- a/examples/ephemeral/s3_cache/variables.tf
+++ b/examples/ephemeral/s3_cache/variables.tf
@@ -1,0 +1,9 @@
+variable "config" {
+  type = object({
+    aws_region       = string
+    prefix           = string
+    runner_role_arns = list(string)
+    tags             = map(string)
+    vpc_id           = string
+  })
+}

--- a/examples/ephemeral/s3_cache/versions.tf
+++ b/examples/ephemeral/s3_cache/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.21"
+    }
+  }
+}

--- a/examples/lambdas-download/.terraform.lock.hcl
+++ b/examples/lambdas-download/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 6.21.0"
   hashes = [
     "h1:PTgxp+nMDBd6EFHAIH6ceFfvwa2blqkCwXglZn6Dqa8=",
+    "h1:zfVzyJmwHhNP+YtLuroU36LTjuZTv2pBUpEJgtnX4HA=",
     "zh:3995ca97e6c2c1ed9e231c453287585d3dc1ca2a304683ac0b269b3448fda7c0",
     "zh:4f69f70d2edeb0dde9c693b7cd7e8e21c781b2fac7062bed5300092dbadb71e1",
     "zh:5c76042fdf3df56a1f581bc477e5d6fc3e099d4d6544fe725b3747e9990726bd",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = "~> 3.0"
   hashes = [
     "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",

--- a/images/ubuntu-noble/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-noble/github_agent.ubuntu.pkr.hcl
@@ -1,0 +1,225 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 0.0.2"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+variable "runner_version" {
+  description = "The version (no v prefix) of the runner software to install https://github.com/actions/runner/releases. The latest release will be fetched from GitHub if not provided."
+  default     = "2.333.0"
+}
+
+variable "region" {
+  description = "The region to build the image in"
+  type        = string
+  default     = "eu-west-1"
+}
+
+variable "security_group_id" {
+  description = "The ID of the security group Packer will associate with the builder to enable access"
+  type        = string
+  default     = null
+}
+
+variable "subnet_id" {
+  description = "If using VPC, the ID of the subnet, such as subnet-12345def, where Packer will launch the EC2 instance. This field is required if you are using an non-default VPC"
+  type        = string
+  default     = null
+}
+
+variable "associate_public_ip_address" {
+  description = "If using a non-default VPC, there is no public IP address assigned to the EC2 instance. If you specified a public subnet, you probably want to set this to true. Otherwise the EC2 instance won't have access to the internet"
+  type        = string
+  default     = null
+}
+
+variable "instance_type" {
+  description = "The instance type Packer will use for the builder"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "iam_instance_profile" {
+  description = "IAM instance profile Packer will use for the builder. An empty string (default) means no profile will be assigned."
+  type        = string
+  default     = ""
+}
+
+variable "root_volume_size_gb" {
+  type    = number
+  default = 16
+}
+
+variable "ebs_delete_on_termination" {
+  description = "Indicates whether the EBS volume is deleted on instance termination."
+  type        = bool
+  default     = true
+}
+
+variable "global_tags" {
+  description = "Tags to apply to everything"
+  type        = map(string)
+  default     = {}
+}
+
+variable "ami_tags" {
+  description = "Tags to apply to the AMI"
+  type        = map(string)
+  default     = {}
+}
+
+variable "snapshot_tags" {
+  description = "Tags to apply to the snapshot"
+  type        = map(string)
+  default     = {}
+}
+
+variable "custom_shell_commands" {
+  description = "Additional commands to run on the EC2 instance, to customize the instance, like installing packages"
+  type        = list(string)
+  default     = []
+}
+
+variable "temporary_security_group_source_public_ip" {
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
+  type        = bool
+  default     = false
+}
+
+data "http" github_runner_release_json {
+  url = "https://api.github.com/repos/actions/runner/releases/latest"
+  request_headers = {
+    Accept = "application/vnd.github+json"
+    X-GitHub-Api-Version : "2022-11-28"
+  }
+}
+
+locals {
+  runner_version = coalesce(var.runner_version, trimprefix(jsondecode(data.http.github_runner_release_json.body).tag_name, "v"))
+}
+
+source "amazon-ebs" "githubrunner" {
+  ami_name                                  = "github-runner-ubuntu-noble-amd64-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  instance_type                             = var.instance_type
+  iam_instance_profile                      = var.iam_instance_profile
+  region                                    = var.region
+  security_group_id                         = var.security_group_id
+  subnet_id                                 = var.subnet_id
+  associate_public_ip_address               = var.associate_public_ip_address
+  temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
+
+  source_ami_filter {
+    filters = {
+      name                = "*ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["099720109477"]
+  }
+  ssh_username = "ubuntu"
+  tags = merge(
+    var.global_tags,
+    var.ami_tags,
+    {
+      OS_Version    = "ubuntu-noble"
+      Release       = "Latest"
+      Base_AMI_Name = "{{ .SourceAMIName }}"
+  })
+  snapshot_tags = merge(
+    var.global_tags,
+    var.snapshot_tags,
+  )
+
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_size           = "${var.root_volume_size_gb}"
+    volume_type           = "gp3"
+    delete_on_termination = "${var.ebs_delete_on_termination}"
+  }
+}
+
+build {
+  name = "githubactions-runner"
+  sources = [
+    "source.amazon-ebs.githubrunner"
+  ]
+  provisioner "shell" {
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive"
+    ]
+    inline = concat([
+      "sudo cloud-init status --wait",
+      "sudo fallocate -l 4G /swapfile",
+      "sudo chmod 600 /swapfile",
+      "sudo mkswap /swapfile",
+      "sudo swapon /swapfile",
+      "echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab > /dev/null",
+      "sudo apt-get -y update",
+      "sudo apt-get -y install ca-certificates curl gnupg lsb-release software-properties-common",
+      "sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg",
+      "echo deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null",
+      "sudo curl -fsSLo /etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg",
+      "echo deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null",
+      "sudo add-apt-repository --yes ppa:ansible/ansible",
+      "sudo apt-get -y update",
+      "sudo apt-get -y install ansible docker-ce docker-ce-cli containerd.io jq git git-lfs unzip gh python3-botocore python3-boto3 python3-venv",
+      "sudo systemctl enable containerd.service",
+      "sudo service docker start",
+      "sudo usermod -a -G docker ubuntu",
+      "sudo curl -f https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb -o amazon-cloudwatch-agent.deb",
+      "sudo dpkg -i amazon-cloudwatch-agent.deb",
+      "sudo systemctl restart amazon-cloudwatch-agent",
+      "sudo curl -f https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip",
+      "unzip awscliv2.zip",
+      "sudo ./aws/install",
+      "sudo curl -f https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb -o session-manager-plugin.deb",
+      "sudo dpkg -i session-manager-plugin.deb",
+    ], var.custom_shell_commands)
+  }
+
+  provisioner "file" {
+    content = templatefile("../install-runner.sh", {
+      install_runner = templatefile("../../modules/runners/templates/install-runner.sh", {
+        ARM_PATCH                       = ""
+        S3_LOCATION_RUNNER_DISTRIBUTION = ""
+        RUNNER_ARCHITECTURE             = "x64"
+      })
+    })
+    destination = "/tmp/install-runner.sh"
+  }
+
+  provisioner "shell" {
+    environment_vars = [
+      "RUNNER_TARBALL_URL=https://github.com/actions/runner/releases/download/v${local.runner_version}/actions-runner-linux-x64-${local.runner_version}.tar.gz"
+    ]
+    inline = [
+      "sudo chmod +x /tmp/install-runner.sh",
+      "echo ubuntu | tee -a /tmp/install-user.txt",
+      "sudo RUNNER_ARCHITECTURE=x64 RUNNER_TARBALL_URL=$RUNNER_TARBALL_URL /tmp/install-runner.sh",
+      "echo ImageOS=ubuntu24 | tee -a /opt/actions-runner/.env"
+    ]
+  }
+
+  provisioner "file" {
+    content = templatefile("../start-runner.sh", {
+      start_runner = templatefile("../../modules/runners/templates/start-runner.sh", { metadata_tags = "enabled" })
+    })
+    destination = "/tmp/start-runner.sh"
+  }
+
+  provisioner "shell" {
+    inline = [
+      "sudo mv /tmp/start-runner.sh /var/lib/cloud/scripts/per-boot/start-runner.sh",
+      "sudo chmod +x /var/lib/cloud/scripts/per-boot/start-runner.sh",
+    ]
+  }
+
+  post-processor "manifest" {
+    output     = "manifest.json"
+    strip_path = true
+  }
+}

--- a/modules/runners/logging.tf
+++ b/modules/runners/logging.tf
@@ -37,7 +37,7 @@ locals {
     "log_group_name" : l.prefix_log_group ? "/github-self-hosted-runners/${var.prefix}/${l.log_group_name}" : "/${l.log_group_name}"
     "log_stream_name" : l.log_stream_name
     "file_path" : l.file_path
-    "log_class" : l.log_class
+    "log_group_class" : l.log_class
   }] : []
 
   loggroups_names = distinct([for l in local.logfiles : l.log_group_name])
@@ -45,7 +45,7 @@ locals {
   # This maintains the same order as loggroups_names for use with count
   loggroups_classes = [
     for name in local.loggroups_names : [
-      for l in local.logfiles : l.log_class
+      for l in local.logfiles : l.log_group_class
       if l.log_group_name == name
     ][0]
   ]


### PR DESCRIPTION
## Description

This PR adds IL-custom features on top of the updated upstream repo after it was moved into a new org, as well as a major version bump from 6.1.2 to 7.5.0
- custom S3 docker caching solution
- custom AMI for runners, based on Ubuntu Noble
- updated lambdas
- updated GitHub Actions Runner to latest 2.333.0
- upstream [fix](https://github.com/github-aws-runners/terraform-aws-github-runner/pull/5073) for `log_class` bug, will be included in 7.5.1
